### PR TITLE
Don't compile material3 to JVM

### DIFF
--- a/material3/build.gradle.kts
+++ b/material3/build.gradle.kts
@@ -47,7 +47,6 @@ kotlin {
     jvmToolchain(17)
     explicitApi()
 
-    jvm()
     androidTarget {
         publishLibraryVariants("release")
     }


### PR DESCRIPTION
It seems like material3 doesn't properly support JVM, so let's skip that for now