### PR TITLE
Create a variety of overloads for different menu item UI components

### DIFF
--- a/material3/src/commonMain/kotlin/com/boswelja/menuprovider/material3/ExposedDropdownMenuItems.kt
+++ b/material3/src/commonMain/kotlin/com/boswelja/menuprovider/material3/ExposedDropdownMenuItems.kt
@@ -3,6 +3,10 @@ package com.boswelja.menuprovider.material3
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.boswelja.menuprovider.LocalMenuHost
 import com.boswelja.menuprovider.MenuHost
@@ -39,4 +43,24 @@ public fun ExposedDropdownMenuItems(
             }
         }
     }
+}
+
+/**
+ * Displays a standard "overflow" button that, when pressed, reveals a dropdown menu containing all
+ * items provided by [menuHost].
+ */
+@Composable
+public fun ExposedDropdownMenuItems(
+    modifier: Modifier = Modifier,
+    menuHost: MenuHost = LocalMenuHost.current,
+    dropdownItemContent: @Composable (MenuItem) -> Unit = { DropdownMenuItem(it) }
+) {
+    var expanded by rememberSaveable { mutableStateOf(false) }
+    ExposedDropdownMenuItems(
+        expanded = expanded,
+        onExpandedChange = { expanded = !expanded },
+        modifier = modifier,
+        menuHost = menuHost,
+        dropdownItemContent = dropdownItemContent
+    )
 }

--- a/material3/src/commonMain/kotlin/com/boswelja/menuprovider/material3/TopAppBarMenuItems.kt
+++ b/material3/src/commonMain/kotlin/com/boswelja/menuprovider/material3/TopAppBarMenuItems.kt
@@ -1,5 +1,7 @@
 package com.boswelja.menuprovider.material3
 
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.ContentTransform
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
@@ -17,60 +19,93 @@ import androidx.compose.ui.Modifier
 import com.boswelja.menuprovider.AnimatedMenuItems
 import com.boswelja.menuprovider.LocalMenuHost
 import com.boswelja.menuprovider.MenuHost
+import com.boswelja.menuprovider.MenuItem
+
+/**
+ * Takes the menu items provided to [menuHost] and displays them in such a way that is suitable for
+ * a Material 3 TopAppBar. Animations are applied automatically via [AnimatedMenuItems].
+ */
+@Composable
+public fun AnimatedTopAppBarMenuItems(
+    modifier: Modifier = Modifier,
+    menuHost: MenuHost = LocalMenuHost.current,
+    maxVisibleActions: Int = 3,
+    transitionSpec: AnimatedContentTransitionScope<List<MenuItem>>.() -> ContentTransform =
+        { fadeIn() togetherWith fadeOut() }
+) {
+    AnimatedMenuItems(
+        transitionSpec = transitionSpec,
+        menuHost = menuHost
+    ) { menuItems ->
+        TopAppBarMenuItems(
+            menuItems = menuItems,
+            modifier = modifier,
+            maxVisibleActions = maxVisibleActions
+        )
+    }
+}
 
 /**
  * Takes the menu items provided to [menuHost] and displays them in such a way that is suitable for
  * a Material 3 TopAppBar.
  */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 public fun TopAppBarMenuItems(
     modifier: Modifier = Modifier,
     menuHost: MenuHost = LocalMenuHost.current,
-    maxVisibleActions: Int = 3
+    maxVisibleActions: Int = 3,
 ) {
-    AnimatedMenuItems(
-        transitionSpec = { fadeIn() togetherWith fadeOut() },
-        menuHost = menuHost
-    ) { menuItems ->
-        val hasOverflow by remember(menuItems, maxVisibleActions) {
-            derivedStateOf { menuItems.count() > maxVisibleActions }
-        }
-        Row(modifier) {
-            if (hasOverflow) {
-                val visibleItemRange = remember(menuItems, maxVisibleActions) {
-                    0..<maxVisibleActions
-                }
-                val overflowItemRange = remember(menuItems, maxVisibleActions) {
-                    maxVisibleActions..<menuItems.size
-                }
+    TopAppBarMenuItems(
+        menuItems = menuHost.menuItems,
+        modifier = modifier,
+        maxVisibleActions = maxVisibleActions
+    )
+}
 
-                visibleItemRange.forEach {
-                    IconButtonMenuItem(menuItems[it])
-                }
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun TopAppBarMenuItems(
+    menuItems: List<MenuItem>,
+    modifier: Modifier = Modifier,
+    maxVisibleActions: Int = 3,
+) {
+    val hasOverflow by remember(menuItems, maxVisibleActions) {
+        derivedStateOf { menuItems.count() > maxVisibleActions }
+    }
+    Row(modifier) {
+        if (hasOverflow) {
+            val visibleItemRange = remember(menuItems, maxVisibleActions) {
+                0..<maxVisibleActions
+            }
+            val overflowItemRange = remember(menuItems, maxVisibleActions) {
+                maxVisibleActions..<menuItems.size
+            }
 
-                var menuExpanded by rememberSaveable { mutableStateOf(false) }
-                ExposedDropdownMenuBox(expanded = menuExpanded, onExpandedChange = { menuExpanded = !menuExpanded }) {
-                    IconButtonMenuItem(
-                        menuItem = DefaultMenuItems
-                            .moreOptions {
-                                menuExpanded = !menuExpanded
-                            },
-                        modifier = Modifier.menuAnchor()
-                    )
-                    ExposedDropdownMenu(
-                        expanded = menuExpanded,
-                        onDismissRequest = { menuExpanded = false }
-                    ) {
-                        overflowItemRange.forEach {
-                            DropdownMenuItem(menuItems[it])
-                        }
+            visibleItemRange.forEach {
+                IconButtonMenuItem(menuItems[it])
+            }
+
+            var menuExpanded by rememberSaveable { mutableStateOf(false) }
+            ExposedDropdownMenuBox(expanded = menuExpanded, onExpandedChange = { menuExpanded = !menuExpanded }) {
+                IconButtonMenuItem(
+                    menuItem = DefaultMenuItems
+                        .moreOptions {
+                            menuExpanded = !menuExpanded
+                        },
+                    modifier = Modifier.menuAnchor()
+                )
+                ExposedDropdownMenu(
+                    expanded = menuExpanded,
+                    onDismissRequest = { menuExpanded = false }
+                ) {
+                    overflowItemRange.forEach {
+                        DropdownMenuItem(menuItems[it])
                     }
                 }
-            } else {
-                menuItems.forEach { menuItem ->
-                    IconButtonMenuItem(menuItem)
-                }
+            }
+        } else {
+            menuItems.forEach { menuItem ->
+                IconButtonMenuItem(menuItem)
             }
         }
     }


### PR DESCRIPTION
- Renamed `TopAppBarMenuItems` to `AnimatedTopAppBarMenuItems`
  - `TopAppBarMenuItems` no longer has an animation by default
- Created `ExposedDropdownMenuItems` that doesn't require state hoisting