### PR TITLE
Separate publishing targets by job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  publish:
+  publish-github:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -20,11 +20,33 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2.7.0
       - name: Build
-        run: ./gradlew publish --scan
+        run: ./gradlew publishAllPublicationsToGithubRepository --scan
         env:
           PUBLISHING: true
           ORG_GRADLE_PROJECT_githubUsername: boswelja
           ORG_GRADLE_PROJECT_githubToken: ${{ secrets.GITHUB_TOKEN }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+
+  publish-oss:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Java JDK
+        uses: actions/setup-java@v3.9.0
+        with:
+          java-version: 17
+          distribution: temurin
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2.7.0
+      - name: Build
+        run: ./gradlew publishAllPublicationsToOssRepository --scan
+        env:
+          PUBLISHING: true
           ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
           ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
@@ -32,7 +54,9 @@ jobs:
 
   upload-pages:
     runs-on: ubuntu-latest
-    needs: publish
+    needs:
+      - publish-github
+      - publish-oss
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An AndroidX MenuHost & MenuProvider-like API for Jetpack Compose!
 
 ```kt
 dependencies {
-    val menuproviderVersion = "1.2.0"
+    val menuproviderVersion = "1.2.1"
     
     // Core provides a generic implementation fit for any design system
     implementation("io.github.boswelja.menuprovider:core:$menuproviderVersion")

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ android.useAndroidX=true
 kotlin.code.style=official
 
 # Below here is all packaging details, not build configuration.
-version=1.2.0
+version=1.2.1
 group=io.github.boswelja.menuprovider


### PR DESCRIPTION
Now we can rerun individual steps when one fails, and one failed target doesn't fail the other.